### PR TITLE
Unable to read date format columns (int96 type) from avro-parquet sch…

### DIFF
--- a/src/main/java/com/databricks/labs/delta/sharing/java/format/parquet/TableReader.java
+++ b/src/main/java/com/databricks/labs/delta/sharing/java/format/parquet/TableReader.java
@@ -98,10 +98,14 @@ public class TableReader<T> {
    */
   private List<ParquetReader<T>> getReaders() throws IOException {
     List<ParquetReader<T>> readers = new LinkedList<>();
+    Configuration conf = new Configuration();
+
+    conf.set("parquet.avro.readInt96AsFixed", "true");
+
     for (Path path : paths) {
       LocalInputFile localInputFile = new LocalInputFile(path);
       ParquetReader<T> reader =
-          AvroParquetReader.<T>builder(localInputFile).build();
+          AvroParquetReader.<T>builder(localInputFile).withConf(conf).build();
       readers.add(reader);
     }
     return readers;

--- a/src/main/java/com/databricks/labs/delta/sharing/java/format/parquet/TableReader.java
+++ b/src/main/java/com/databricks/labs/delta/sharing/java/format/parquet/TableReader.java
@@ -1,5 +1,6 @@
 package com.databricks.labs.delta.sharing.java.format.parquet;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 


### PR DESCRIPTION
…ema (#22)

INT96 is deprecated so we must set "parquet.avro.readInt96AsFixed" configuration to "true" when build the reader.